### PR TITLE
make the module work in Qt5

### DIFF
--- a/Logic/vtkSlicerVolumeResliceDriverLogic.cxx
+++ b/Logic/vtkSlicerVolumeResliceDriverLogic.cxx
@@ -22,6 +22,7 @@
 #include "vtkMRMLLinearTransformNode.h"
 #include "vtkMRMLScalarVolumeNode.h"
 #include "vtkMRMLSliceNode.h"
+#include "vtkMRMLScene.h"
 
 // VTK includes
 #include <vtkCollection.h>

--- a/qSlicerVolumeResliceDriverModule.cxx
+++ b/qSlicerVolumeResliceDriverModule.cxx
@@ -26,7 +26,9 @@
 #include "qSlicerVolumeResliceDriverModuleWidget.h"
 
 //-----------------------------------------------------------------------------
-Q_EXPORT_PLUGIN2(qSlicerVolumeResliceDriverModule, qSlicerVolumeResliceDriverModule);
+#if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
+    Q_EXPORT_PLUGIN2(qSlicerVolumeResliceDriverModule, qSlicerVolumeResliceDriverModule);
+#endif
 
 //-----------------------------------------------------------------------------
 /// \ingroup Slicer_QtModules_VolumeResliceDriver

--- a/qSlicerVolumeResliceDriverModule.h
+++ b/qSlicerVolumeResliceDriverModule.h
@@ -22,6 +22,7 @@
 #include "qSlicerLoadableModule.h"
 
 #include "qSlicerVolumeResliceDriverModuleExport.h"
+#include <QtGlobal>
 
 class qSlicerVolumeResliceDriverModulePrivate;
 
@@ -30,6 +31,9 @@ class Q_SLICER_QTMODULES_VOLUMERESLICEDRIVER_EXPORT qSlicerVolumeResliceDriverMo
   public qSlicerLoadableModule
 {
   Q_OBJECT
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
+      Q_PLUGIN_METADATA(IID "org.slicer.modules.loadable.qSlicerLoadableModule/1.0");
+#endif
   Q_INTERFACES(qSlicerLoadableModule);
 
 public:


### PR DESCRIPTION
Q_EXPORT_PLUGIN2 macros have been deprecated in favor of the new Q_PLUGIN_METADATA macro

https://wiki.qt.io/Transition_from_Qt_4.x_to_Qt5